### PR TITLE
Changes to the plugin

### DIFF
--- a/src/phaser-state-transition.js
+++ b/src/phaser-state-transition.js
@@ -48,6 +48,13 @@
 		_draw.call(this, state);
 	};
 
+	/** Can be called in the create function of states that you transition to, to ensure
+	  * that the transition-sprite is on top of everything
+	  */
+	Phaser.Plugin.StateTransition.prototype.bringToTop = function () {
+		_bringCoverToTop.call(this);
+	}
+
 	Phaser.Plugin.StateTransition.prototype.settings = function (opt) {
 		if (opt) {
 			for(var p in opt) {
@@ -69,6 +76,13 @@
 		}
 	};
 
+	/*Move the Texture-Sprite to the top*/
+	function _bringCoverToTop() {
+		if (this._cover) {
+			this._cover.bringToTop();
+		}
+	}
+
 	/* Draw the world state */
 	function _draw(state) {
 
@@ -85,15 +99,16 @@
 			this._texture = this.game.add.renderTexture('cover', this.game.width, this.game.height);
 		}
 		/* Draw the current world to the render */
-		this._texture.renderXY(this.game.world, 0, 0, true);
+		this._texture.renderXY(this.game.world, -this.game.camera.x, -this.game.camera.y, true);
 
 		/* If there's a state as a paramterer change the state and do the dew */
 		if (state) {
 			
 			this.game.state.start(state);
 
-			this._cover = this.game.add.sprite(this.game.world.centerX, this.game.world.centerY, this._texture);
-			this._cover.anchor.setTo(0.5, 0.5);
+			this._cover = this.game.add.sprite(game.width / 2, game.height / 2, this._texture);
+			this._cover.anchor.setTo(0.5,0.5);
+			this._cover.fixedToCamera = true;
 		}
 
 		/* Resume the game */


### PR DESCRIPTION
Hi Cristian (or xnamex, first name just guessed from your github-username)

First of all, thanks for the plugin, I think it's really usefull and brings a much needed feature to phaser.

I have made three changes to get the plugin working with my game (explanations below):

a) I added a bringToTop Method, that calls bringToTop on the transition sprite

b) I changed the code that renders the world into the texture (it takes into account that the camera might have been moved)

c) Attached the transition-sprite to the camera (instead of placing it in the center of the world), this point has phaser version dependecy.

All three were needed in my game to use your transitions.

Explanation:

a) was needed, because the create function of one of the states I transition to creates multiple sprites, that (because they are created after the transition-sprite) are in front of the transition-sprite. The only way I found to fix this, is calling the bringToTop Method at the end of the create function of the state. (Maybe this can be done in a nicer way that does not force you to call the method in every state? If so, I do not know how.)

b) This was needed when transitioning from my tiled-map-game state when the player has moved into the level (the camera follows the player into the level). So the world group is way bigger than one screen. if we just render it at 0.0, then the wrong part of the world is rendered to the sprite (and since it's out of view of the camera the sprites are culled and nothing at all is rednered.) By rendering to -camera.x, -camera.y exactly the visible part is rendered into the sprited. (at least it worked perfectly for my game.)

c) since my world size changed between states I "lost" the transition-sprite somewhere sometimes, so I changed the positioning of the sprite so that it's fixed to the camera and thereby independend of world size. this point is problematic.. because with phaser 1.1.4 this places the sprite just where it needs to be. with phaser 1.1.3 the sprite coordinates have to be 0,0 (instead of game.size.x /2, game.size.y /2)

This is my first pull request, I hope it went ok :)
You might want to take out the point c, if you want to stay with phaser 1.1.3 for now.
(Also when 1.1.4 is released I will have to check again, if the change is still needed, for now I work with phaser 1.1.4 from 3 weeks ago.)

If you have any questions, contact me.

Greetings,
Jan Peter (jpdev on the phaser forums)
