### PR TITLE
Optional fillColor for transition

### DIFF
--- a/src/phaser-state-transition.js
+++ b/src/phaser-state-transition.js
@@ -59,7 +59,7 @@
 	Phaser.Plugin.StateTransition.prototype.settings = function (opt) {
 		if (opt) {
 			for(var p in opt) {
-				if (settings[p]) {
+				if (settings.hasOwnProperty(p)) {
 					settings[p] = opt[p];
 				}
 			}
@@ -68,8 +68,10 @@
 		}
 	};
 
-	/* Settings object */
+	/* Default-Settings object */
 	var settings = {
+		useFillColor: false,
+		fillColor: 0x000000,
 		duration: 300, /* ms */
 		ease: Phaser.Easing.Exponential.InOut,
 		properties: {
@@ -99,8 +101,28 @@
 		if (!this._texture) {
 			this._texture = this.game.add.renderTexture('cover', this.game.width, this.game.height);
 		}
+
+	    if (settings.useFillColor) {
+		    /* Create a temp Graphics object */
+		    var tempGraphic = game.add.graphics(0, 0);
+		    /* Fill it in the fillColor */
+		    tempGraphic.beginFill(settings.fillColor);
+		    tempGraphic.lineStyle(1, settings.fillColor, 1);
+		    tempGraphic.drawRect(0, 0, game.width, game.height);
+		    tempGraphic.endFill();
+		    //render it to the texture
+		    this._texture.renderXY(tempGraphic, 0, 0);
+		    /* clear it, so it's not visible in the world */
+		    tempGraphic.clear();
+		}
+
 		/* Draw the current world to the render */
-		this._texture.renderXY(this.game.world, -this.game.camera.x, -this.game.camera.y, true);
+		this._texture.renderXY(this.game.world, -this.game.camera.x, -this.game.camera.y, !settings.useFillColor);
+
+		if (tempGraphic != null) {
+			/* if a tempGraphic has been used, destroy it now */
+			tempGraphic.destroy();
+		}
 
 		/* If there's a state as a paramterer change the state and do the dew */
 		if (state) {


### PR DESCRIPTION
Hi Cristian,

I have again made changes to your plugin.

One is kind of a bugfix, it's line 62:
you checked settings[p] for true/false, this did not allow to have boolean properties in settings that were default false. (because then, they would never be set, because settings['useFillColor'] for example would evaluate to false.) - I changed it to hasOwnProperty (it's what stack overflow suggested, it checks if the object settings has the property p).

The other change is a feature - it is an option to color the transition texture before the world is drawn to it.

Reason behind the feature:
If the game always paints the complete screen without leaving any holes, then this option is of course not needed. My game (and I guess some other games) just sets a background color and draws only the needed sprites, the background color acts as a sky/background. Now, if this world is drawn into the transition texture, it has "holes" where the texture is still clear, so you see the new state through these "holes" during the transition. (because the worlds background color is not drawn to the texture, only the sprites.)
Using the fillColor option (by setting useFillColor to true, and fillColor to the desired color) there are no longer "holes" in the transition texture and the transition looks better.
(The only way I knew how to do this was to paint a graphics object and render it to the texture, if you know a better way to draw to a texture, please let me know!)

I tested it in canvas and webGL mode. (But still using my phaser 1.1.4 build from 2 weeks ago, so you might want to double check if you want to merge it.)

Also: This time I made a feature branch in my fork of the phaser-state-transition repo. (Still learning git.. after you accepted my first pull request, I did not manage to get my fork to the same code as your original.. (I had to delete my fork and refork) maybe with this feature branch, i can then update my master correctly.. that's my hope at least.)

Greetings,
JP
