### PR TITLE
Added Background Color Support

### DIFF
--- a/src/phaser-state-transition.js
+++ b/src/phaser-state-transition.js
@@ -108,7 +108,8 @@
 		tempGraphic.endFill();
 		/* adding it to the texture before the world render */
 		this._texture.renderXY(tempGraphic, 0, 0);
-		tempGraphic.clear(); //cleanup
+		/* cleanup */
+		tempGraphic.clear();
 
 		/* Draw the current world to the render */
 		this._texture.renderXY(this.game.stage, -this.game.camera.x, -this.game.camera.y);

--- a/src/phaser-state-transition.js
+++ b/src/phaser-state-transition.js
@@ -106,7 +106,8 @@
 		tempGraphic.lineStyle(1,this.game.stage.backgroundColor, 1);
 		tempGraphic.drawRect(0, 0, this.game.width, this.game.height);
 		tempGraphic.endFill();
-		this._texture.renderXY(tempGraphic, 0, 0); //adding it to the texture before the world render
+		/* adding it to the texture before the world render */
+		this._texture.renderXY(tempGraphic, 0, 0);
 		tempGraphic.clear(); //cleanup
 
 		/* Draw the current world to the render */

--- a/src/phaser-state-transition.js
+++ b/src/phaser-state-transition.js
@@ -99,6 +99,16 @@
 		if (!this._texture) {
 			this._texture = new Phaser.RenderTexture(this.game, this.game.width, this.game.height, 'cover');
 		}
+
+		/* We want the current background color in the transition, just in case the entire frame isn't covered by sprites. */
+		var tempGraphic = this.game.add.graphics(0, 0);
+		tempGraphic.beginFill(this.game.stage.backgroundColor);
+		tempGraphic.lineStyle(1,this.game.stage.backgroundColor, 1);
+		tempGraphic.drawRect(0, 0, this.game.width, this.game.height);
+		tempGraphic.endFill();
+		this._texture.renderXY(tempGraphic, 0, 0); //adding it to the texture before the world render
+		tempGraphic.clear(); //cleanup
+
 		/* Draw the current world to the render */
 		this._texture.renderXY(this.game.stage, -this.game.camera.x, -this.game.camera.y);
 


### PR DESCRIPTION
Added background color support for scenes that aren’t filling the entire frame in sprites.

The idea for setting a custom color for the transparency of the transition was from jpdev.
I just removed the selectable color, and just made it the current background color for simplicity.